### PR TITLE
12章まで

### DIFF
--- a/tdd-by-example-swift.xcodeproj/project.pbxproj
+++ b/tdd-by-example-swift.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		E40678CA1FA6C63600955667 /* MoneyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40678C91FA6C63600955667 /* MoneyTest.swift */; };
 		E40678CC1FA6C66E00955667 /* Dollar.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40678CB1FA6C66E00955667 /* Dollar.swift */; };
 		E45036871FB1422400C3225A /* Money.swift in Sources */ = {isa = PBXBuildFile; fileRef = E45036861FB1422400C3225A /* Money.swift */; };
+		E4676FF21FBB2F87004E9A85 /* Bank.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4676FF11FBB2F87004E9A85 /* Bank.swift */; };
+		E4676FF41FBB31A1004E9A85 /* Expressible.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4676FF31FBB31A1004E9A85 /* Expressible.swift */; };
 		E4D180651FA6B325005D1668 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D180641FA6B325005D1668 /* AppDelegate.swift */; };
 		E4D180671FA6B325005D1668 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D180661FA6B325005D1668 /* ViewController.swift */; };
 		E4D1806A1FA6B325005D1668 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E4D180681FA6B325005D1668 /* Main.storyboard */; };
@@ -50,6 +52,8 @@
 		E40678C91FA6C63600955667 /* MoneyTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoneyTest.swift; sourceTree = "<group>"; };
 		E40678CB1FA6C66E00955667 /* Dollar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dollar.swift; sourceTree = "<group>"; };
 		E45036861FB1422400C3225A /* Money.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Money.swift; sourceTree = "<group>"; };
+		E4676FF11FBB2F87004E9A85 /* Bank.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bank.swift; sourceTree = "<group>"; };
+		E4676FF31FBB31A1004E9A85 /* Expressible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Expressible.swift; sourceTree = "<group>"; };
 		E4D180611FA6B325005D1668 /* tdd-by-example-swift.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "tdd-by-example-swift.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E4D180641FA6B325005D1668 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E4D180661FA6B325005D1668 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -144,6 +148,8 @@
 			isa = PBXGroup;
 			children = (
 				E45036861FB1422400C3225A /* Money.swift */,
+				E4676FF11FBB2F87004E9A85 /* Bank.swift */,
+				E4676FF31FBB31A1004E9A85 /* Expressible.swift */,
 				E40678CB1FA6C66E00955667 /* Dollar.swift */,
 				95677CF81FB0815900DE7E96 /* Franc.swift */,
 				E4D180641FA6B325005D1668 /* AppDelegate.swift */,
@@ -472,7 +478,9 @@
 				95677CF91FB0815900DE7E96 /* Franc.swift in Sources */,
 				E45036871FB1422400C3225A /* Money.swift in Sources */,
 				E4D180671FA6B325005D1668 /* ViewController.swift in Sources */,
+				E4676FF21FBB2F87004E9A85 /* Bank.swift in Sources */,
 				E4D180651FA6B325005D1668 /* AppDelegate.swift in Sources */,
+				E4676FF41FBB31A1004E9A85 /* Expressible.swift in Sources */,
 				E40678CC1FA6C66E00955667 /* Dollar.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/tdd-by-example-swift.xcodeproj/project.pbxproj
+++ b/tdd-by-example-swift.xcodeproj/project.pbxproj
@@ -15,7 +15,7 @@
 		E40678CC1FA6C66E00955667 /* Dollar.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40678CB1FA6C66E00955667 /* Dollar.swift */; };
 		E45036871FB1422400C3225A /* Money.swift in Sources */ = {isa = PBXBuildFile; fileRef = E45036861FB1422400C3225A /* Money.swift */; };
 		E4676FF21FBB2F87004E9A85 /* Bank.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4676FF11FBB2F87004E9A85 /* Bank.swift */; };
-		E4676FF41FBB31A1004E9A85 /* Expressible.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4676FF31FBB31A1004E9A85 /* Expressible.swift */; };
+		E4676FF41FBB31A1004E9A85 /* Expression.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4676FF31FBB31A1004E9A85 /* Expression.swift */; };
 		E4D180651FA6B325005D1668 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D180641FA6B325005D1668 /* AppDelegate.swift */; };
 		E4D180671FA6B325005D1668 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D180661FA6B325005D1668 /* ViewController.swift */; };
 		E4D1806A1FA6B325005D1668 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E4D180681FA6B325005D1668 /* Main.storyboard */; };
@@ -53,7 +53,7 @@
 		E40678CB1FA6C66E00955667 /* Dollar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dollar.swift; sourceTree = "<group>"; };
 		E45036861FB1422400C3225A /* Money.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Money.swift; sourceTree = "<group>"; };
 		E4676FF11FBB2F87004E9A85 /* Bank.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bank.swift; sourceTree = "<group>"; };
-		E4676FF31FBB31A1004E9A85 /* Expressible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Expressible.swift; sourceTree = "<group>"; };
+		E4676FF31FBB31A1004E9A85 /* Expression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Expression.swift; sourceTree = "<group>"; };
 		E4D180611FA6B325005D1668 /* tdd-by-example-swift.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "tdd-by-example-swift.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E4D180641FA6B325005D1668 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E4D180661FA6B325005D1668 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -149,7 +149,7 @@
 			children = (
 				E45036861FB1422400C3225A /* Money.swift */,
 				E4676FF11FBB2F87004E9A85 /* Bank.swift */,
-				E4676FF31FBB31A1004E9A85 /* Expressible.swift */,
+				E4676FF31FBB31A1004E9A85 /* Expression.swift */,
 				E40678CB1FA6C66E00955667 /* Dollar.swift */,
 				95677CF81FB0815900DE7E96 /* Franc.swift */,
 				E4D180641FA6B325005D1668 /* AppDelegate.swift */,
@@ -480,7 +480,7 @@
 				E4D180671FA6B325005D1668 /* ViewController.swift in Sources */,
 				E4676FF21FBB2F87004E9A85 /* Bank.swift in Sources */,
 				E4D180651FA6B325005D1668 /* AppDelegate.swift in Sources */,
-				E4676FF41FBB31A1004E9A85 /* Expressible.swift in Sources */,
+				E4676FF41FBB31A1004E9A85 /* Expression.swift in Sources */,
 				E40678CC1FA6C66E00955667 /* Dollar.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/tdd-by-example-swift/Bank.swift
+++ b/tdd-by-example-swift/Bank.swift
@@ -9,7 +9,7 @@ import Foundation
 
 class Bank {
     
-    func reduce(_ source: Expressible, _ to: String) -> Money {
+    func reduce(_ source: Expression, _ to: String) -> Money {
         return Money.doller(10)
     }
 }

--- a/tdd-by-example-swift/Bank.swift
+++ b/tdd-by-example-swift/Bank.swift
@@ -1,0 +1,9 @@
+//
+//  Bank.swift
+//  tdd-by-example-swift
+//
+//  Copyright © 2017年 cm-pliser. All rights reserved.
+//
+
+import Foundation
+

--- a/tdd-by-example-swift/Bank.swift
+++ b/tdd-by-example-swift/Bank.swift
@@ -7,3 +7,9 @@
 
 import Foundation
 
+class Bank {
+    
+    func reduce(_ source: Expressible, _ to: String) -> Money {
+        return Money.doller(10)
+    }
+}

--- a/tdd-by-example-swift/Expressible.swift
+++ b/tdd-by-example-swift/Expressible.swift
@@ -6,3 +6,7 @@
 //
 
 import Foundation
+
+protocol Expressible {
+    
+}

--- a/tdd-by-example-swift/Expressible.swift
+++ b/tdd-by-example-swift/Expressible.swift
@@ -1,0 +1,8 @@
+//
+//  Expressible.swift
+//  tdd-by-example-swift
+//
+//  Copyright © 2017年 cm-pliser. All rights reserved.
+//
+
+import Foundation

--- a/tdd-by-example-swift/Expression.swift
+++ b/tdd-by-example-swift/Expression.swift
@@ -7,6 +7,6 @@
 
 import Foundation
 
-protocol Expressible {
+protocol Expression {
     
 }

--- a/tdd-by-example-swift/Money.swift
+++ b/tdd-by-example-swift/Money.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class Money: Equatable, CustomStringConvertible, Expressible {
+class Money: Equatable, CustomStringConvertible, Expression {
     
     // 本の中ではprotectedだが、swiftではできないのでpublic扱いに
     let amount: Int
@@ -35,7 +35,7 @@ class Money: Equatable, CustomStringConvertible, Expressible {
         return Money(amount * multiplier, currency)
     }
     
-    func plus(_ addend: Money) -> Expressible {
+    func plus(_ addend: Money) -> Expression {
         return Money(amount + addend.amount, currency)
     }
     

--- a/tdd-by-example-swift/Money.swift
+++ b/tdd-by-example-swift/Money.swift
@@ -35,6 +35,10 @@ class Money: Equatable, CustomStringConvertible {
         return Money(amount * multiplier, currency)
     }
     
+    func plus(_ addend: Money) -> Money {
+        return Money(amount + addend.amount, currency)
+    }
+    
     var description: String {
         return "\(amount) \(currency)"
     }

--- a/tdd-by-example-swift/Money.swift
+++ b/tdd-by-example-swift/Money.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class Money: Equatable, CustomStringConvertible {
+class Money: Equatable, CustomStringConvertible, Expressible {
     
     // 本の中ではprotectedだが、swiftではできないのでpublic扱いに
     let amount: Int
@@ -35,7 +35,7 @@ class Money: Equatable, CustomStringConvertible {
         return Money(amount * multiplier, currency)
     }
     
-    func plus(_ addend: Money) -> Money {
+    func plus(_ addend: Money) -> Expressible {
         return Money(amount + addend.amount, currency)
     }
     

--- a/tdd-by-example-swiftTests/MoneyTest.swift
+++ b/tdd-by-example-swiftTests/MoneyTest.swift
@@ -52,8 +52,11 @@ class MoneyTest: QuickSpec {
         }
         
         it("testSimpleAddition") {
-            let sum: Money = Money.doller(5).plus(Money.doller(5))
-            expect(sum).to(equal(Money.doller(10)))
+            let five: Money = Money.doller(5)
+            let sum: Expressible = five.plus(five)
+            let bank: Bank = Bank()
+            let reduced = bank.reduce(sum, "USD")
+            expect(reduced).to(equal(Money.doller(10)))
         }
     }
 }

--- a/tdd-by-example-swiftTests/MoneyTest.swift
+++ b/tdd-by-example-swiftTests/MoneyTest.swift
@@ -53,7 +53,7 @@ class MoneyTest: QuickSpec {
         
         it("testSimpleAddition") {
             let five: Money = Money.doller(5)
-            let sum: Expressible = five.plus(five)
+            let sum: tdd_by_example_swift.Expression = five.plus(five)
             let bank: Bank = Bank()
             let reduced = bank.reduce(sum, "USD")
             expect(reduced).to(equal(Money.doller(10)))

--- a/tdd-by-example-swiftTests/MoneyTest.swift
+++ b/tdd-by-example-swiftTests/MoneyTest.swift
@@ -50,5 +50,10 @@ class MoneyTest: QuickSpec {
             expect("USD").to(equal(Money.doller(1).currency))
             expect("CHF").to(equal(Money.franc(1).currency))
         }
+        
+        it("testSimpleAddition") {
+            let sum: Money = Money.doller(5).plus(Money.doller(5))
+            expect(sum).to(equal(Money.doller(10)))
+        }
     }
 }

--- a/tdd-by-example-swiftTests/MoneyTest.swift
+++ b/tdd-by-example-swiftTests/MoneyTest.swift
@@ -13,6 +13,7 @@ import Nimble
  TODO
  
  [ ] $5 + 10CHF = $10
+ [ ] $5 + $5 = $10
  [x] $5 * 2 = $10
  [x] amountをprivateにする
  [x] Dollarの副作用どうする?


### PR DESCRIPTION
以下の理由で「式」を表す命名を `Expression` ではなく `Expressible`とした

- 書籍ではExpressionだが、NimbleのExpressionと名前衝突するため
- protocol として定義するので、Swift的な命名規則を採用した