### PR TITLE
Currencyをenumで定義する

### DIFF
--- a/tdd-by-example-swift/Money.swift
+++ b/tdd-by-example-swift/Money.swift
@@ -8,12 +8,16 @@
 import Foundation
 
 class Money: Equatable, CustomStringConvertible {
+    enum Currency {
+        case usd
+        case chf
+    }
     
     // 本の中ではprotectedだが、swiftではできないのでpublic扱いに
     let amount: Int
-    let currency: String
+    let currency: Currency
     
-    init(_ amount: Int, _ currency: String) {
+    init(_ amount: Int, _ currency: Currency) {
         self.amount = amount
         self.currency = currency
     }
@@ -24,11 +28,11 @@ class Money: Equatable, CustomStringConvertible {
     }
     
     class func doller(_ amount: Int) -> Money {
-        return Money(amount, "USD")
+        return Money(amount, .usd)
     }
     
     class func franc(_ amount: Int) -> Money {
-        return Money(amount, "CHF")
+        return Money(amount, .chf)
     }
     
     func times(_ multiplier: Int) -> Money? {

--- a/tdd-by-example-swiftTests/MoneyTest.swift
+++ b/tdd-by-example-swiftTests/MoneyTest.swift
@@ -46,8 +46,8 @@ class MoneyTest: QuickSpec {
         }
         
         it("testCurrency") {
-            expect("USD").to(equal(Money.doller(1).currency))
-            expect("CHF").to(equal(Money.franc(1).currency))
+            expect(Money.Currency.usd).to(equal(Money.doller(1).currency))
+            expect(Money.Currency.chf).to(equal(Money.franc(1).currency))
         }
     }
 }


### PR DESCRIPTION
# Why
- Stringによる定義よりもenumによる定義の方がTypoを防いだり、型での表現ができるため、良いから

# What
- enumを使うことでよりSwiftらしいコードにした